### PR TITLE
define vocabulary for DeepBlue-specific properties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,11 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # # Use Capistrano for deployment
 # # gem 'capistrano-rails', group: :development
 #
+
+group :development do
+  gem 'pry'
+end
+
  group :development, :test do
 #   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
      gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.2)
-    mini_magick (4.3.3)
+    mini_magick (4.3.5)
     mini_portile (0.6.2)
     minitest (5.8.1)
     mono_logger (1.1.0)
@@ -458,7 +458,7 @@ GEM
       net-http-persistent (~> 2.9)
       rdf (~> 1.1)
     spring (1.4.0)
-    sprockets (3.3.5)
+    sprockets (3.4.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
       actionpack (>= 3.0)
@@ -508,6 +508,7 @@ DEPENDENCIES
   jettywrapper
   jquery-rails
   orm_adapter
+  pry
   pry-byebug
   puma
   rails (= 4.2.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,6 @@ module MiD
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.action_controller.relative_url_root = '/demo01'
     config.active_record.raise_in_transactional_callbacks = true
+    config.autoload_paths += Dir["#{config.root}/lib/**/"]
   end
 end

--- a/lib/deep_blue.rb
+++ b/lib/deep_blue.rb
@@ -1,0 +1,2 @@
+module DeepBlue
+end

--- a/lib/deep_blue/vocab.rb
+++ b/lib/deep_blue/vocab.rb
@@ -1,0 +1,4 @@
+module DeepBlue
+  module Vocab
+  end
+end

--- a/lib/deep_blue/vocab/terms.rb
+++ b/lib/deep_blue/vocab/terms.rb
@@ -1,0 +1,54 @@
+# -*- encoding: utf-8 -*-
+require 'rdf'
+module DeepBlue
+  module Vocab
+    class Terms < RDF::StrictVocabulary('http://lib.umich.edu/models#')
+
+      property :dateAccessioned,
+        label: "Date Accessioned".freeze,
+        subPropertyOf: "dc:date".freeze,
+        type: "rdf:Property".freeze
+
+      property :dateAvailable,
+        label: "Date Available".freeze,
+        subPropertyOf: "dc:date".freeze,
+        type: "rdf:Property".freeze
+
+      property :dateIssued,
+        label: "Date Issued".freeze,
+        subPropertyOf: "dc:date".freeze,
+        type: "rdf:Property".freeze
+
+      property :citation,
+        label: "Citation".freeze,
+        subPropertyOf: "dc:identifier".freeze,
+        type: "rdf:Property".freeze
+
+      property :handleUrl,
+        label: "Handle URL".freeze,
+        subPropertyOf: "dc:identifier".freeze,
+        type: "rdf:Property".freeze
+
+      property :classification,
+        label: "Classification".freeze,
+        subPropertyOf: "dc:subject".freeze,
+        type: "rdf:Property".freeze
+
+      property :affiliationUMCampus,
+        label: "UM Campus".freeze,
+        subPropertyOf: "dcterms:contributor".freeze,
+        type: "rdf:Property".freeze
+
+      property :hlbTopLevel,
+        label: "HLB Top Level".freeze,
+        subPropertyOf: "dc:subject".freeze,
+        type: "rdf:Property".freeze
+
+      property :hlbSecondLevel,
+        label: "HLB Second Level".freeze,
+        subPropertyOf: "dc:subject".freeze,
+        type: "rdf:Property".freeze
+
+    end
+  end
+end


### PR DESCRIPTION
- add pry for rails console use
- define vocabulary for DeepBlue-specific properties
- configure autoloading of `lib` paths so custom vocab use is as seamless as `Hydra::PCDM::Vocab`
