### PR TITLE
setup basic admin users for devise/cancancan

### DIFF
--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -1,6 +1,15 @@
 development:
   archivist:
     - archivist1@example.com
+  admin:
+    - harry@hogwarts.edu
+    - roger@umich.edu
+    - njaffer@umich.edu
+    - blancoj@umich.edu
+    - gordonl@umich.edu
+    - krenee@umich.edu
+    - khage@umich.edu
+    - jweise@umich.edu
 test:
   archivist:
     - archivist1@example.com

--- a/lib/tasks/prototype.rake
+++ b/lib/tasks/prototype.rake
@@ -1,0 +1,27 @@
+namespace :prototype do
+    desc 'install default admin users'
+    task :install_admin_users => :environment do
+      admin_users = [
+        'roger@umich.edu',
+        'njaffer@umich.edu',
+        'blancoj@umich.edu',
+        'gordonl@umich.edu',
+        'krenee@umich.edu',
+        'khage@umich.edu',
+        'jweise@umich.edu',
+      ]
+
+      admin_users.each do |email|
+        u = User.where(email: email).first
+        if u.nil?
+          u = User.create!(email: email, password: 'mgoblue!')
+          if u.nil?
+            STDERR.puts "#{email} not created"
+          else
+            STDERR.puts "installed: #{u.id} : #{u.email} : #{u.guest}"
+          end
+        end
+      end
+
+    end
+end


### PR DESCRIPTION
Install admin users with

```
bundle exec rake prototype:install_admin_users
```

Not very exciting, but gets us started.
