### PR TITLE
34 setup user roles groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'responders'
 gem 'warden'
 gem 'bcrypt'
 gem 'thread_safe'
+
+gem 'hydra-role-management'
+
 #gem 'pry'
 ## Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/mlibrary/umichwrapper.git
-  revision: 5fcf5fb91290799c4a1710069866a6bcde27be90
+  revision: ad164104ba6d0753b1a1f91e108590914a68e8d9
   branch: master
   specs:
-    umichwrapper (0.1.0)
+    umichwrapper (0.2.0)
       activesupport (>= 3.0.0)
       i18n
       logger
@@ -53,7 +53,7 @@ GEM
     active_fedora-noid (1.0.2)
       active-fedora (~> 9.0)
       noid (~> 0.7)
-    activefedora-aggregation (0.4.1)
+    activefedora-aggregation (0.4.2)
       active-fedora
       activesupport
       rdf-vocab (~> 0.8.1)
@@ -90,8 +90,8 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 3.2.6, < 5)
       rsolr (~> 1.0.11)
-    blacklight_advanced_search (5.1.4)
-      blacklight (~> 5.10)
+    blacklight_advanced_search (5.2.0)
+      blacklight (~> 5.15)
       parslet
     blankslate (3.1.3)
     bootstrap-sass (3.3.5.1)
@@ -101,7 +101,7 @@ GEM
     builder (3.2.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    cancancan (1.12.0)
+    cancancan (1.13.1)
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.0)
@@ -156,7 +156,7 @@ GEM
     ethon (0.8.0)
       ffi (>= 1.3.0)
     execjs (2.6.0)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     globalid (0.3.6)
@@ -189,12 +189,12 @@ GEM
       hydra-file_characterization (~> 0.3)
       mime-types (< 3)
       mini_magick (>= 3.2, < 5)
-    hydra-editor (1.0.4)
+    hydra-editor (1.1.0)
       active-fedora (>= 9.0.0)
       cancancan (~> 1.8)
       rails (~> 4.1)
       simple_form (~> 3.1.0)
-    hydra-file_characterization (0.3.2)
+    hydra-file_characterization (0.3.3)
       activesupport (>= 3.0.0)
     hydra-head (9.2.2)
       hydra-access-controls (= 9.2.2)
@@ -223,7 +223,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    json-ld (1.1.10)
+    json-ld (1.1.11)
       multi_json (~> 1.11)
       rdf (~> 1.1, >= 1.1.7)
     kaminari (0.16.3)
@@ -234,7 +234,7 @@ GEM
       http_logger
       linkeddata (>= 1.1)
       slop
-    libv8 (3.16.14.11)
+    libv8 (3.16.14.13)
     link_header (0.0.8)
     linkeddata (1.1.11)
       equivalent-xml (~> 0.5)
@@ -264,7 +264,7 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.2)
-    mini_magick (4.3.5)
+    mini_magick (4.3.6)
     mini_portile (0.6.2)
     minitest (5.8.1)
     mono_logger (1.1.0)
@@ -288,7 +288,7 @@ GEM
     orm_adapter (0.5.0)
     parslet (1.7.1)
       blankslate (>= 2.0, <= 4.0)
-    pry (0.10.2)
+    pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -328,7 +328,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    rdf (1.1.16.1)
+    rdf (1.1.17.1)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (1.1.0)
       rdf (>= 1.1)
@@ -374,7 +374,7 @@ GEM
     rdf-turtle (1.1.8)
       ebnf (~> 0.3, >= 0.3.6)
       rdf (~> 1.1, >= 1.1.10)
-    rdf-vocab (0.8.5)
+    rdf-vocab (0.8.6)
       rdf (~> 1.1, >= 1.1.10)
     rdf-xsd (1.1.4)
       rdf (~> 1.1, >= 1.1.9)
@@ -391,11 +391,10 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    resque-pool (0.5.0)
+    resque-pool (0.6.0)
       rake
       resque (~> 1.22)
-      trollop (~> 2.0)
-    rsolr (1.0.12)
+    rsolr (1.0.13)
       builder (>= 2.1.2)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
@@ -415,7 +414,7 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
     rubyzip (1.1.7)
-    sass (3.4.18)
+    sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -466,7 +465,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
+    sqlite3 (1.3.11)
     stomp (1.3.4)
     sxp (0.1.5)
     temple (0.7.6)
@@ -476,7 +475,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
-    trollop (2.1.2)
     turbolinks (2.5.3)
       coffee-rails
     typhoeus (0.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
+    bootstrap_form (2.3.0)
     breadcrumbs_on_rails (2.3.1)
     builder (3.2.2)
     byebug (5.0.0)
@@ -203,6 +204,10 @@ GEM
     hydra-pcdm (0.1.0)
       activefedora-aggregation (~> 0.4)
       mime-types (>= 1)
+    hydra-role-management (0.2.2)
+      blacklight
+      bootstrap_form
+      cancancan
     hydra-works (0.1.0)
       active-fedora (~> 9.2)
       activefedora-aggregation (~> 0.4)
@@ -504,6 +509,7 @@ DEPENDENCIES
   curation_concerns
   devise
   devise-guests (~> 0.3)
+  hydra-role-management
   jbuilder (~> 2.0)
   jettywrapper
   jquery-rails
@@ -528,6 +534,3 @@ DEPENDENCIES
   umichwrapper!
   warden
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,7 +520,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   byebug
-  curation_concerns (= 0.1)
+  curation_concerns
   devise
   devise-guests (~> 0.3)
   hydra-role-management

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,15 +2,30 @@ class Ability
   include Hydra::Ability
   
   include CurationConcerns::Ability
-  self.ability_logic += [:everyone_can_create_curation_concerns]
+  ### self.ability_logic += [:everyone_can_create_curation_concerns]
 
   # Define any customized permissions here.
   def custom_permissions
+    if current_user.admin?
+      can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
+    end
+
     # Limits deleting objects to a the admin user
     #
-    # if current_user.admin?
-    #   can [:destroy], ActiveFedora::Base
-    # end
+    if current_user.admin?
+      can [:destroy], ActiveFedora::Base
+    end
+
+    if current_user.has_role?('collection.manager') or current_user.admin?
+      # can [:create, :show, :index, :edit, :update, :destroy], Collection
+      can [:create], Collection
+    end
+
+    if current_user.has_role?('collection.depositor') or current_user.has_group_role?('collection.depositor')
+      # can [:create, :show, :index, :edit, :update, :destroy], [ CurationConcerns.configuration.curation_concerns ]
+      can [:create], [ CurationConcerns.configuration.curation_concerns ]
+      # can [:show], Collection
+    end
 
     # Limits creating new objects to a specific group
     #

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,14 @@
+class Group < ActiveRecord::Base
+  has_and_belongs_to_many :users
+  has_and_belongs_to_many :roles
+
+  def has_role?(role)
+    self.roles.where(name: role).exists?
+  end
+
+  validates :name, 
+    uniqueness: true,
+    format: { with: /\A[a-zA-Z0-9._-]+\z/,
+      :message => "Only letters, numbers, hyphens, underscores and periods are allowed"}
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,37 @@
 class User < ActiveRecord::Base
   # Connects this user object to Hydra behaviors.
   include Hydra::User
+  # Connects this user object to Role-management behaviors.
+  include Hydra::RoleManagement::UserRoles
+
+
   # Connects this user object to Curation Concerns behaviors.
   include CurationConcerns::User
 
+  # :groups is defined by CurationConcerns::User.groups
+  has_and_belongs_to_many :user_groups, class_name: 'Group'
+
+  def has_role?(role)
+    self.roles.where(name: role).exists? or has_group_role?(role)
+  end
+
+  def has_group?(group)
+    # self.groups.where(name: group).exists?
+    not(self.groups.index(group).nil?)
+  end
+
+  def has_group_role?(role)
+    user_groups.joins(:roles).where('roles.name' => role).exists?
+  end
+  
+  def groups
+    # for reals?
+    user_groups.collect { |g| g.name }
+  end
+
+  def admin?
+    roles.where(name: 'admin').exists? or has_group_role?('admin')
+  end
 
 
   if Blacklight::Utils.needs_attr_accessible?

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,6 +1,6 @@
 development:
   adapter: solr
-  url: http://localhost:8080/tomcat/quod-dev/solr-hydra/njaffer-dev
+  url: <%= ENV['SOLR_URL'] || "http://localhost:8080/tomcat/quod-dev/solr-hydra" %>/njaffer-dev
 test: &test
   adapter: solr
   url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/test" %>

--- a/config/initializers/patch_role.rb
+++ b/config/initializers/patch_role.rb
@@ -1,0 +1,1 @@
+require 'add_group_to_role'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   root to: "catalog#index"
   blacklight_for :catalog
   devise_for :users
+  mount Hydra::RoleManagement::Engine => '/'
+
   mount Hydra::Collections::Engine => '/'
   mount CurationConcerns::Engine, at: '/'
   curation_concerns_collections

--- a/db/migrate/20151028150731_user_roles.rb
+++ b/db/migrate/20151028150731_user_roles.rb
@@ -1,0 +1,18 @@
+class UserRoles < ActiveRecord::Migration
+  def up
+    create_table :roles do |t|
+      t.string :name
+    end
+    create_table :roles_users, :id => false do |t|
+      t.references :role
+      t.references :user
+    end
+    add_index :roles_users, [:role_id, :user_id]
+    add_index :roles_users, [:user_id, :role_id]
+  end
+
+  def down
+    drop_table :roles_users
+    drop_table :roles
+  end
+end

--- a/db/migrate/20151028150831_create_groups.rb
+++ b/db/migrate/20151028150831_create_groups.rb
@@ -1,0 +1,25 @@
+class CreateGroups < ActiveRecord::Migration
+  def up
+    create_table :groups do |t|
+      t.string :name
+    end
+    create_table :groups_users, :id => false do |t|
+      t.references :group
+      t.references :user
+    end
+    create_table :groups_roles, :id => false do |t|
+      t.references :role
+      t.references :group
+    end
+    add_index :groups_users, [:group_id, :user_id]
+    add_index :groups_users, [:user_id, :group_id]
+    add_index :groups_roles, [:group_id, :role_id]
+    add_index :groups_roles, [:role_id, :group_id]
+  end
+
+  def down
+    drop_table :groups_users
+    drop_table :groups_roles
+    drop_table :groups
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151001125820) do
+ActiveRecord::Schema.define(version: 20151028150831) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -37,6 +37,38 @@ ActiveRecord::Schema.define(version: 20151001125820) do
   end
 
   add_index "checksum_audit_logs", ["generic_file_id", "file_id"], name: "by_generic_file_id_and_file_id"
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "groups_roles", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "group_id"
+  end
+
+  add_index "groups_roles", ["group_id", "role_id"], name: "index_groups_roles_on_group_id_and_role_id"
+  add_index "groups_roles", ["role_id", "group_id"], name: "index_groups_roles_on_role_id_and_group_id"
+
+  create_table "groups_users", id: false, force: :cascade do |t|
+    t.integer "group_id"
+    t.integer "user_id"
+  end
+
+  add_index "groups_users", ["group_id", "user_id"], name: "index_groups_users_on_group_id_and_user_id"
+  add_index "groups_users", ["user_id", "group_id"], name: "index_groups_users_on_user_id_and_group_id"
+
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "user_id"
+  end
+
+  add_index "roles_users", ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+  add_index "roles_users", ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
 
   create_table "searches", force: :cascade do |t|
     t.text     "query_params"

--- a/lib/add_group_to_role.rb
+++ b/lib/add_group_to_role.rb
@@ -1,0 +1,8 @@
+module AddGroupToRole
+  extend ActiveSupport::Concern
+  included do
+    has_and_belongs_to_many :groups
+  end  
+end
+
+Role.send(:include, AddGroupToRole)

--- a/lib/role_mapper.rb
+++ b/lib/role_mapper.rb
@@ -1,0 +1,7 @@
+class RoleMapper
+  def self.roles(uid)
+    u = User.find_by_email(uid)
+    return [] unless u
+    u.roles.collect { |r| r.name }
+  end
+end

--- a/lib/tasks/prototype.rake
+++ b/lib/tasks/prototype.rake
@@ -1,27 +1,126 @@
 namespace :prototype do
-    desc 'install default admin users'
-    task :install_admin_users => :environment do
-      admin_users = [
-        'roger@umich.edu',
-        'njaffer@umich.edu',
-        'blancoj@umich.edu',
-        'gordonl@umich.edu',
-        'krenee@umich.edu',
-        'khage@umich.edu',
-        'jweise@umich.edu',
-      ]
+  desc 'install sample roles'
+  task :install_sample_roles => :environment do
+    [ 'admin', 'collection.manager', 'collection.depositor' ].each do |name|
+      r = Role.find_by_name(name)
+      if r.nil?
+        r = Role.new name: name
+        r.save
+        STDERR.puts "installed role: #{r.name}"
+      end
+    end
+  end
 
-      admin_users.each do |email|
-        u = User.where(email: email).first
+  desc 'install superusers group'
+  task :install_superusers_group => :environment do
+    r = Role.find_by_name('admin')
+    g = Group.new name: 'superusers'
+    g.save
+    g.roles << r
+  end
+
+  desc 'install superusers'
+  task :install_superusers => :environment do
+    admin_users = [
+      'roger@umich.edu',
+      'njaffer@umich.edu',
+      'blancoj@umich.edu',
+      'gordonl@umich.edu',
+      'krenee@umich.edu',
+      'khage@umich.edu',
+      'jweise@umich.edu',
+    ]
+
+    g = Group.find_by_name('superusers')
+    admin_users.each do |email|
+      u = User.where(email: email).first
+      if u.nil?
+        u = User.create!(email: email, password: 'mgoblue!')
         if u.nil?
-          u = User.create!(email: email, password: 'mgoblue!')
-          if u.nil?
-            STDERR.puts "#{email} not created"
-          else
-            STDERR.puts "installed: #{u.id} : #{u.email} : #{u.guest}"
-          end
+          STDERR.puts "#{email} not created"
+        else
+          STDERR.puts "installed: #{u.id} : #{u.email} : #{u.guest}"
         end
       end
-
+      u.user_groups << g
     end
+  end
+
+  desc 'add user'
+  task :add_user, [:email, :password, :group] => :environment do |t, args|
+    args.with_defaults(:password => 'mgoblue!', :group => nil)
+    email = args[:email]
+    password = args[:password] == '' ? 'mgoblue!' : args[:password]
+    group = args[:group]
+    u = User.where(email: email).first
+    if u.nil?
+      u = User.create!(email: email, password: password)
+      if u.nil?
+        STDERR.puts "#{email} not created"
+      else
+        STDERR.puts "installed: #{u.id} : #{u.email}"
+      end
+    end
+    if group
+      g = Group.find_by_name(group)
+      u.user_groups << g
+      STDERR.puts "updated: #{email} : #{group}"
+    end
+  end
+
+  desc 'add role to user'
+  task :add_role_to_user, [:role, :email] => :environment do |t, args|
+    u = User.find_by_email(args[:email])
+    r = Role.find_by_name(args[:role])
+    u.roles << r
+  end
+
+  desc 'add role to group'
+  task :add_role_to_group, [:role, :group] => :environment do |t, args|
+    g = Group.find_by_name(args[:group])
+    r = Role.find_by_name(args[:role])
+    g.roles << r
+  end
+
+  desc 'add user to group'
+  task :add_user_to_group, [:email, :group] => :environment do |t, args|
+    g = Group.find_by_name(args[:group])
+    u = User.find_by_email(args[:email])
+    u.user_groups << g
+  end
+
+  desc 'add group'
+  task :add_group, [:name, :role] => :environment do |t, args|
+    name = args[:name]
+    role = args[:role]
+    g = Group.where(name: name).first
+    if g.nil?
+      g = Group.create!(name: name)
+      if g.nil?
+        STDERR.puts "#{name} not created"
+      else
+        STDERR.puts "installed: #{g.id} : #{g.name}"
+      end
+    end
+    if role
+      r = Role.find_by_name(role)
+      g.roles << r
+      STDERR.puts "updated: #{name} : #{role}"
+    end
+  end
+
+  desc 'add role'
+  task :add_role, [:name] => :environment do |t, args|
+    name = args[:name]
+    r = Role.where(name: name).first
+    if r.nil?
+      r = Role.create!(name: name)
+      if r.nil?
+        STDERR.puts "#{name} not created"
+      else
+        STDERR.puts "installed: #{r.id} : #{r.name}"
+      end
+    end
+  end
+
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
closes: #34  --- apologies for the messy commits. Was not on the branch I thought I was on.)
- configures `hydra-role-management`
- adds `Group` model
- adds a `groups` relationship to `Role`
- updates the prototype rake tasks
- updates `user.rb` to define `admin?` by role or by the user's group roles
- updates `ability.rb` to play with restrictions; these are not what we'll want for real, but if you want to _demonstrate_ permissions...

To use after merging:

``` bash
$ bundle exec rake db:migrate
$ bundle exec rake prototype:install_sample_roles
$ bundle exec rake prototype:install_superusers_group
$ bundle exec rake prototype:install_superusers # same users, adds them to the superusers group
```

The installed roles are `admin`, `collection.manager`, `collection.depositor`.

After setup, you can do

``` bash
$ bundle exec rake prototype:add_role['my.new.role']
$ bundle exec rake prototype:add_group['my.new.group','my.new.role']
$ bundle exec rake prototype:add_user['user@example.com','password','my.new.group']
# if password is blank ('') then it will be "mgloblue!"
$ bundle exec rake prototype:add_role_to_user['my.new.role','user@example.com']
$ bundle exec rake prototype:add_role_to_group['my.new.role','my.new.group']
$ bundle exec rake prototype:add_user_to_group['user@example.com','my.new.group']
```
