### PR TITLE
return solr_doc if no dateIssued; dateIssuedYear is not a predicate

### DIFF
--- a/app/models/concerns/deep_blue/basic_metadata.rb
+++ b/app/models/concerns/deep_blue/basic_metadata.rb
@@ -8,9 +8,9 @@ module DeepBlue
 
       property :dateIssued, predicate: DeepBlue::Vocab::Terms.dateIssued, multiple: false 
 
-      property :dateIssuedYear, predicate: DeepBlue::Vocab::Terms.dateIssuedYear, multiple: false do |index|
-        index.as :stored_sortable, :facetable
-      end
+      # property :dateIssuedYear, predicate: DeepBlue::Vocab::Terms.dateIssuedYear, multiple: false do |index|
+      #   index.as :stored_sortable, :facetable
+      # end
 
       property :classification, predicate: DeepBlue::Vocab::Terms.classification, multiple: false
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,8 +7,8 @@ class Item < ActiveFedora::Base
   validates_presence_of :title,  message: 'Your work must have a title.'
 
   def to_solr(solr_doc = {})
-    if dateIssued
-      super(solr_doc).tap do |solr_doc|
+    super(solr_doc).tap do |solr_doc|
+      if dateIssued
         solr_doc['dateIssuedYear_sim'] = dateIssued[0,4]
       end
     end


### PR DESCRIPTION
- dateIssuedYear should be computed, not something persisted to Fedora --- that's what the `to_solr` thinks
- modified `to_solr` so solr_doc is returned if the Item does not have `dateIssued`
